### PR TITLE
update to CoreNLP 3.9.1 and switch to an actually-maintained base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:jre-alpine
+FROM openjdk:8-jre-alpine
 
 MAINTAINER Shayne Miel <miel.shayne@gmail.com>
 
@@ -6,7 +6,7 @@ RUN apk add --update --no-cache \
 	 unzip \
 	 wget
 
-ARG CORENLP_RELEASE=stanford-corenlp-full-2016-10-31
+ARG CORENLP_RELEASE=stanford-corenlp-full-2018-02-27
 
 RUN wget http://nlp.stanford.edu/software/$CORENLP_RELEASE.zip
 RUN unzip $CORENLP_RELEASE.zip && \

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Dockerfile for Stanford CoreNLP Server
 This Dockerfile builds the [Stanford CoreNLP Server](http://stanfordnlp.github.io/CoreNLP/corenlp-server.html)
 and exposes the endpoint on port 9000. Requests are made as covered in the documentation.
 
-Latest version is [CoreNLP 3.7.0](http://nlp.stanford.edu/software/stanford-corenlp-full-2016-10-31.zip)
+Latest version is [CoreNLP 3.9.1](http://nlp.stanford.edu/software/stanford-corenlp-full-2018-02-27.zip)


### PR DESCRIPTION
update to CoreNLP 3.9.1 and switch to an actually-maintained base image (https://hub.docker.com/r/library/java/ is deprecated in favor of openjdk)